### PR TITLE
Add image output format and quality support

### DIFF
--- a/webscreenshot.js
+++ b/webscreenshot.js
@@ -18,10 +18,12 @@
 # along with webscreenshot.	 If not, see <http://www.gnu.org/licenses/>.
 ***/
 
-var Page = (function(custom_headers, http_username, http_password, image_width, image_height) {
+var Page = (function(custom_headers, http_username, http_password, image_width, image_height, image_format, image_quality) {
 	var opts = {
 		width: image_width || 1200,
 		height: image_height || 800,
+		format: image_format || 'png',
+		quality: image_quality || 70,
 		ajaxTimeout: 400,
 		maxTimeout: 800,
 		httpAuthErrorCode: 2
@@ -93,7 +95,7 @@ var Page = (function(custom_headers, http_username, http_password, image_width, 
 			document.body.bgColor = 'white';
 		});
 
-		page.render(opts.file);
+		page.render(opts.file, {format: opts.format, quality: opts.quality});
 		phantom.exit(0);
 	}
 
@@ -121,6 +123,13 @@ function main() {
 
 	var p_height = new RegExp('height=(.*)');
 	var image_height = '';
+
+	var p_format = new RegExp('format=(.*)');
+	var image_format = '';
+
+	var p_quality = new RegExp('quality=(.*)');
+	var image_quality = '';
+
 	var temp_custom_headers = {
 		// Nullify Accept-Encoding header to disable compression (https://github.com/ariya/phantomjs/issues/10930)
 		'Accept-Encoding': ' '
@@ -166,16 +175,26 @@ function main() {
 		{
 			image_height = p_height.exec(system.args[i])[1];
 		}
+
+		if (p_format.test(system.args[i]) === true)
+		{
+			image_format = p_format.exec(system.args[i])[1];
+		}
+
+		if (p_quality.test(system.args[i]) === true)
+		{
+			image_quality = p_quality.exec(system.args[i])[1];
+		}
 	}
 
 	if (typeof(URL) === 'undefined' || URL.length == 0 || typeof(output_file) === 'undefined' || output_file.length == 0) {
-		console.log("Usage: phantomjs [options] webscreenshot.js url_capture=<URL> output_file=<output_file.png> [header=<custom header> http_username=<HTTP basic auth username> http_password=<HTTP basic auth password>]");
-		console.log('Please specify an URL to capture and an output png filename !');
-		
+		console.log("Usage: phantomjs [options] webscreenshot.js url_capture=<URL> output_file=<output_file> [header=<custom header> http_username=<HTTP basic auth username> http_password=<HTTP basic auth password>]");
+		console.log('Please specify an URL to capture and an output filename !');
+
 		phantom.exit(1);
 	}
 	else {
-		var page = Page(temp_custom_headers, http_username, http_password, image_width, image_height);
+		var page = Page(temp_custom_headers, http_username, http_password, image_width, image_height, image_format, image_quality);
 		page.render(URL, output_file);
 	}
 }

--- a/webscreenshot.js
+++ b/webscreenshot.js
@@ -26,7 +26,7 @@ var Page = (function(custom_headers, http_username, http_password, image_width, 
 		maxTimeout: 800,
 		httpAuthErrorCode: 2
 	};
-	
+
 	var requestCount = 0;
 	var forceRenderTimeout;
 	var ajaxRenderTimeout;
@@ -36,13 +36,13 @@ var Page = (function(custom_headers, http_username, http_password, image_width, 
 		width: opts.width,
 		height: opts.height
 	};
-	
+
 	page.settings.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1944.0 Safari/537.36';
 	page.settings.userName = http_username;
 	page.settings.password = http_password;
-	
+
 	page.customHeaders = custom_headers;
-	
+
 	page.onInitialized = function() {
 		page.customHeaders = {};
 	};
@@ -58,7 +58,7 @@ var Page = (function(custom_headers, http_username, http_password, image_width, 
 		if (response.stage && response.stage == 'end' && response.status == '401') {
 			page.failReason = '401';
 		}
-		
+
 		if (!response.stage || response.stage === 'end') {
 			requestCount -= 1;
 			if (requestCount === 0) {
@@ -71,7 +71,7 @@ var Page = (function(custom_headers, http_username, http_password, image_width, 
 
 	api.render = function(url, file) {
 		opts.file = file;
-		
+
 		page.open(url, function(status) {
 			if (status !== "success") {
 				if (page.failReason && page.failReason == '401') {
@@ -103,72 +103,71 @@ var Page = (function(custom_headers, http_username, http_password, image_width, 
 });
 
 function main() {
-	
+
 	var system = require('system');
+
 	var p_url = new RegExp('url_capture=(.*)');
 	var p_outfile = new RegExp('output_file=(.*)');
 	var p_header = new RegExp('header=(.*)');
-	
+
 	var p_http_username = new RegExp('http_username=(.*)');
 	var http_username = '';
-	
+
 	var p_http_password = new RegExp('http_password=(.*)');
 	var http_password = '';
 
 	var p_width = new RegExp('width=(.*)');
 	var image_width = '';
-	
+
 	var p_height = new RegExp('height=(.*)');
 	var image_height = '';
-	
 	var temp_custom_headers = {
 		// Nullify Accept-Encoding header to disable compression (https://github.com/ariya/phantomjs/issues/10930)
 		'Accept-Encoding': ' '
 	};
-	
+
 	for(var i = 0; i < system.args.length; i++) {
 		if (p_url.test(system.args[i]) === true)
 		{
 			var URL = p_url.exec(system.args[i])[1];
 		}
-		
+
 		if (p_outfile.test(system.args[i]) === true)
 		{
 			var output_file = p_outfile.exec(system.args[i])[1];
 		}
-		
+
 		if (p_http_username.test(system.args[i]) === true)
 		{
 			http_username = p_http_username.exec(system.args[i])[1];
 		}
-		
+
 		if (p_http_password.test(system.args[i]) === true)
 		{
 			http_password = p_http_password.exec(system.args[i])[1];
 		}
-		
+
 		if (p_header.test(system.args[i]) === true)
 		{
-			var header = p_header.exec(system.args[i]);		
+			var header = p_header.exec(system.args[i]);
 			var p_header_split = header[1].split(': ', 2);
 			var header_name = p_header_split[0];
 			var header_value = p_header_split[1];
-				
+
 			temp_custom_headers[header_name] = header_value;
-			
 		}
-		
+
 		if (p_width.test(system.args[i]) === true)
 		{
 			image_width = p_width.exec(system.args[i])[1];
 		}
-		
+
 		if (p_height.test(system.args[i]) === true)
 		{
 			image_height = p_height.exec(system.args[i])[1];
 		}
 	}
-	
+
 	if (typeof(URL) === 'undefined' || URL.length == 0 || typeof(output_file) === 'undefined' || output_file.length == 0) {
 		console.log("Usage: phantomjs [options] webscreenshot.js url_capture=<URL> output_file=<output_file.png> [header=<custom header> http_username=<HTTP basic auth username> http_password=<HTTP basic auth password>]");
 		console.log('Please specify an URL to capture and an output png filename !');

--- a/webscreenshot.py
+++ b/webscreenshot.py
@@ -65,6 +65,8 @@ screenshot_grp.add_argument('-r', '--renderer', help = '<RENDERER> (optional): r
 screenshot_grp.add_argument('--renderer-binary', help = '<RENDERER_BINARY> (optional): path to the renderer executable if it cannot be found in $PATH')
 screenshot_grp.add_argument('--no-xserver', help = '<NO_X_SERVER> (optional): if you are running without an X server, will use xvfb-run to execute the renderer', action = 'store_true', default = False)
 screenshot_grp.add_argument('--window-size', help = '<WINDOW_SIZE> (optional): width and height of the screen capture (default \'1200,800\')', default = '1200,800')
+screenshot_grp.add_argument('--format', help = '<FORMAT> (optional, phantomjs): specify an output image file format, "pdf", "png", "jpg", "jpeg", "bmp" or "ppm" (default \'png\')', choices = ['pdf', 'png', 'jpg', 'jpeg', 'bmp', 'ppm'], type=str.lower, default = 'png')
+screenshot_grp.add_argument('--quality', help = '<QUALITY> (optional, phantomjs): specify the output image quality, an integer between 0 and 100 (default 70)', default = 70)
 
 proc_grp = parser.add_argument_group('Input processing parameters')
 proc_grp.add_argument('-p', '--port', help = '<PORT> (optional): use the specified port for each target in the input list. Ex: -p 80')
@@ -356,7 +358,7 @@ def craft_cmd(url_and_options):
     logger_url.addHandler(logger_output)
     logger_url.setLevel(options.log_level)
 
-    output_filename = os.path.join(options.output_directory, ('%s.png' % filter_bad_filename_chars(url)))
+    output_filename = os.path.join(options.output_directory, ('%s.%s' % (filter_bad_filename_chars(url),options.format)))
 
     # PhantomJS renderer
     if options.renderer == 'phantomjs':
@@ -379,6 +381,10 @@ def craft_cmd(url_and_options):
 
         cmd_parameters.append('width=%d' % int(options.window_size.split(',')[0]))
         cmd_parameters.append('height=%d' % int(options.window_size.split(',')[1]))
+
+        cmd_parameters.append('format=%s' % options.format)
+        cmd_parameters.append('quality=%d' % int(options.quality))
+
         if options.header:
             for header in options.header:
                 cmd_parameters.append('header="%s"' % header.rstrip(';'))

--- a/webscreenshot.py
+++ b/webscreenshot.py
@@ -41,7 +41,7 @@ import argparse
 if (sys.version_info < (3, 0)):
     os_getcwd = os.getcwdu
     izip = itertools.izip
-    
+
 else:
     os_getcwd = os.getcwd
     izip = zip
@@ -69,7 +69,7 @@ screenshot_grp.add_argument('--window-size', help = '<WINDOW_SIZE> (optional): w
 proc_grp = parser.add_argument_group('Input processing parameters')
 proc_grp.add_argument('-p', '--port', help = '<PORT> (optional): use the specified port for each target in the input list. Ex: -p 80')
 proc_grp.add_argument('-s', '--ssl', help = '<SSL> (optional): enforce ssl for every connection', action = 'store_true', default = False)
-proc_grp.add_argument('-m', '--multiprotocol', help = '<MULTIPROTOCOL> (optional): perform screenshots over HTTP and HTTPS for each target', action = 'store_true', default = False) 
+proc_grp.add_argument('-m', '--multiprotocol', help = '<MULTIPROTOCOL> (optional): perform screenshots over HTTP and HTTPS for each target', action = 'store_true', default = False)
 
 http_grp = parser.add_argument_group('HTTP parameters')
 http_grp.add_argument('-c', '--cookie', help = '<COOKIE_STRING> (optional): cookie string to add. Ex: -c "JSESSIONID=1234; YOLO=SWAG"')
@@ -85,7 +85,7 @@ conn_grp.add_argument('-T', '--proxy-type', help = '<PROXY_TYPE> (optional): spe
 conn_grp.add_argument('-t', '--timeout', help = '<TIMEOUT> (optional): renderer execution timeout in seconds (default 30 sec)', default = 30)
 
 # renderer binaries, hoping to find it in a $PATH directory
-## Be free to change them to your own full-path location 
+## Be free to change them to your own full-path location
 PHANTOMJS_BIN = 'phantomjs'
 CHROME_BIN = 'google-chrome'
 CHROMIUM_BIN = 'chromium'
@@ -126,34 +126,34 @@ entry_from_csv = re.compile('^(?P<host>%s|%s)\s+(?P<port>\d+)$' % (p_domain, p_i
 
 # Handful functions
 def init_worker():
-    """ 
+    """
         Tell the workers to ignore a global SIGINT interruption
     """
     signal.signal(signal.SIGINT, signal.SIG_IGN)
-    
+
 def kill_em_all(signal, frame):
     """
         Terminate all processes while capturing a SIGINT from the user
     """
     logger_gen.info('CTRL-C received, exiting')
     sys.exit(0)
-    
+
 def shell_exec(url, command, options):
     """
         Execute a shell command following a timeout
         Taken from http://howto.pui.ch/post/37471155682/set-timeout-for-a-shell-command-in-python
     """
     global SHELL_EXECUTION_OK, SHELL_EXECUTION_ERROR
-    
+
     logger_url = logging.getLogger("%s" % url)
     logger_url.setLevel(options.log_level)
-    
+
     timeout = int(options.timeout)
     start = datetime.datetime.now()
-    
+
     try :
         p = subprocess.Popen(shlex.split(command, posix="win" not in sys.platform), shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        
+
         # binaries timeout
         while p.poll() is None:
             time.sleep(0.1)
@@ -161,14 +161,14 @@ def shell_exec(url, command, options):
             if (now - start).seconds > timeout:
                 logger_url.debug("Shell command PID %s reached the timeout, killing it now" % p.pid)
                 logger_url.error("Screenshot somehow failed\n")
-                
+
                 if sys.platform == 'win32':
                     p.send_signal(signal.SIGTERM)
                 else:
                     p.send_signal(signal.SIGKILL)
-                
+
                 return SHELL_EXECUTION_ERROR
-        
+
         retval = p.poll()
         if retval != SHELL_EXECUTION_OK:
             if retval == PHANTOMJS_HTTP_AUTH_ERROR_CODE:
@@ -178,21 +178,21 @@ def shell_exec(url, command, options):
                 # Phantomjs general error
                 logger_url.error("Shell command PID %s returned an abnormal error code: '%s'" % (p.pid,retval))
                 logger_url.error("Screenshot somehow failed\n")
-                    
+
             return SHELL_EXECUTION_ERROR
-        
+
         else:
             logger_url.debug("Shell command PID %s ended normally" % p.pid)
             logger_url.info("Screenshot OK\n")
             return SHELL_EXECUTION_OK
-    
+
     except OSError as e:
         if e.errno and e.errno == errno.ENOENT :
             logger_url.error('renderer binary could not have been found in your current PATH environment variable, exiting')
-    
+
     except Exception as err:
         logger_gen.error('Unknown error: %s, exiting' % err)
-        
+
         return SHELL_EXECUTION_ERROR
 
 def filter_bad_filename_chars(filename):
@@ -201,7 +201,7 @@ def filter_bad_filename_chars(filename):
     """
     # Before, just avoid triple underscore escape for the classic '://' pattern
     filename = filename.replace('://', '_')
-    
+
     return re.sub('[^\w\-_\. ]', '_', filename)
 
 def extract_all_matched_named_groups(regex, match):
@@ -212,26 +212,26 @@ def extract_all_matched_named_groups(regex, match):
         >>>full_uri_domain.match('http://8.8.8.8:80').group('domain')
         '8.8.8.8'
         >>>extract_all_matched_named_groups() => {'domain': '8.8.8.8', 'port': '80'}
-            
+
     """
     result = {}
     for name, id in regex.groupindex.items():
         matched_value = match.group(name)
         if matched_value != None: result[name] = matched_value
-    
+
     return result
-    
+
 def entry_format_validator(line):
     """
         Validate the current line against several regexes and return matched parameters (ip, domain, port etc.)
     """
     tab = { 'full_uri_domain'       : full_uri_domain,
             'fqdn_only'             : fqdn_only,
-            'fqdn_and_port'         : fqdn_and_port, 
-            'ipv4_and_port'         : ipv4_and_port, 
-            'ipv4_only'             : ipv4_only, 
+            'fqdn_and_port'         : fqdn_and_port,
+            'ipv4_and_port'         : ipv4_and_port,
+            'ipv4_only'             : ipv4_only,
             'entry_from_csv'        : entry_from_csv }
-    
+
     for name, regex in tab.items():
         validator = regex.match(line)
         if validator:
@@ -239,32 +239,32 @@ def entry_format_validator(line):
 
 def parse_targets(options):
     """
-        Parse list and convert each target to valid URI with port(protocol://foobar:port) 
+        Parse list and convert each target to valid URI with port(protocol://foobar:port)
     """
-    
+
     target_list = []
-    
-    if options.input_file != None:    
+
+    if options.input_file != None:
         with open(options.input_file,'rb') as fd_input:
             try:
                 lines = [l.decode('utf-8').lstrip().rstrip().strip() for l in fd_input.readlines()]
-            
+
             except UnicodeDecodeError as e:
                 logger_gen.error('Your input file is not UTF-8 encoded, please encode it before using this script')
                 sys.exit(0)
     else:
         lines = [options.URL]
-        
+
     for index, line in enumerate(lines, start=1):
         matches = entry_format_validator(line)
-        
+
         # pass if line can be recognized as a correct input, or if no 'host' group could be found with all the regexes
         if matches == None or not('host' in matches.keys()):
             logger_gen.warn("Line %s '%s' could not have been recognized as a correct input" % (index, line))
             pass
         else:
             host = matches['host']
-            
+
             # Protocol is 'http' by default, unless ssl is forced
             if options.ssl == True:
                 protocol = 'https'
@@ -272,70 +272,70 @@ def parse_targets(options):
                 protocol = str(matches['protocol'])
             else:
                 protocol = 'http'
-            
+
             # Port is ('80' for http) or ('443' for https) by default, unless a specific port is supplied
             if options.port != None:
                 port = options.port
             elif 'port' in matches.keys():
                 port = int(matches['port'])
-                
+
                 # if port is 443, assume protocol is https if is not specified
                 protocol = 'https' if port == 443 else protocol
             else:
                 port = 443 if protocol == 'https' else 80
-            
+
             # No resource URI by default
             if 'res' in matches.keys():
                 res = str(matches['res'])
             else:
                 res = None
-            
+
             # perform screenshots over HTTP and HTTPS for each target
             if options.multiprotocol:
                 final_uri_http_port = int(matches['port']) if 'port' in matches.keys() else 80
                 final_uri_http = '%s://%s:%s' % ('http', host, final_uri_http_port)
                 target_list.append(final_uri_http)
                 logger_gen.info("'%s' has been formatted as '%s' with supplied overriding options" % (line, final_uri_http))
-                
-                
+
+
                 final_uri_https_port = int(matches['port']) if 'port' in matches.keys() else 443
                 final_uri_https = '%s://%s:%s' % ('https', host, final_uri_https_port)
                 target_list.append(final_uri_https)
                 logger_gen.info("'%s' has been formatted as '%s' with supplied overriding options" % (line, final_uri_https))
-            
+
             else:
                 final_uri = '%s://%s:%s' % (protocol, host, port)
                 final_uri = final_uri + '/%s' % res if res != None else final_uri
                 target_list.append(final_uri)
 
                 logger_gen.info("'%s' has been formatted as '%s' with supplied overriding options" % (line, final_uri))
-    
+
     return target_list
 
 def craft_bin_path(options):
     global PHANTOMJS_BIN, CHROME_BIN, CHROMIUM_BIN, FIREFOX_BIN, XVFB_BIN
-    
+
     final_bin = []
-    
+
     if options.no_xserver:
         final_bin.append(XVFB_BIN)
-    
-    if options.renderer_binary != None: 
+
+    if options.renderer_binary != None:
         final_bin.append(os.path.join(options.renderer_binary))
-    
+
     else:
         if options.renderer == 'phantomjs':
             final_bin.append(PHANTOMJS_BIN)
-        
+
         elif options.renderer == 'chrome':
             final_bin.append(CHROME_BIN)
-        
+
         elif options.renderer == 'chromium':
             final_bin.append(CHROMIUM_BIN)
-        
+
         elif options.renderer == 'firefox':
             final_bin.append(FIREFOX_BIN)
-        
+
     return " ".join(final_bin)
 
 def craft_arg(param):
@@ -349,15 +349,15 @@ def craft_cmd(url_and_options):
         Craft the correct command with url and options
     """
     global logger_output, WEBSCREENSHOT_JS, SHELL_EXECUTION_OK, SHELL_EXECUTION_ERROR
-    
+
     url, options = url_and_options
-    
+
     logger_url = logging.getLogger("%s" % url)
     logger_url.addHandler(logger_output)
     logger_url.setLevel(options.log_level)
 
     output_filename = os.path.join(options.output_directory, ('%s.png' % filter_bad_filename_chars(url)))
-        
+
     # PhantomJS renderer
     if options.renderer == 'phantomjs':
         # If you ever want to add some voodoo options to the phantomjs command to be executed, that's here right below
@@ -365,27 +365,26 @@ def craft_cmd(url_and_options):
                            '--ignore-ssl-errors=true',
                            '--ssl-protocol=any',
                            '--ssl-ciphers=ALL' ]
-        
+
         cmd_parameters.append("--proxy %s" % options.proxy) if options.proxy != None else None
         cmd_parameters.append("--proxy-auth %s" % options.proxy_auth) if options.proxy_auth != None else None
         cmd_parameters.append("--proxy-type %s" % options.proxy_type) if options.proxy_type != None else None
 
         cmd_parameters.append('%s url_capture=%s output_file=%s' % (craft_arg(WEBSCREENSHOT_JS), url, craft_arg(output_filename)))
-        
+
         cmd_parameters.append('header="Cookie: %s"' % options.cookie.rstrip(';')) if options.cookie != None else None
-        
+
         cmd_parameters.append('http_username=%s' % options.http_username) if options.http_username != None else None
         cmd_parameters.append('http_password=%s' % options.http_password) if options.http_password != None else None
-        
+
         cmd_parameters.append('width=%d' % int(options.window_size.split(',')[0]))
         cmd_parameters.append('height=%d' % int(options.window_size.split(',')[1]))
-        
         if options.header:
             for header in options.header:
                 cmd_parameters.append('header="%s"' % header.rstrip(';'))
-    
+
     # Chrome and chromium renderers
-    elif (options.renderer == 'chrome') or (options.renderer == 'chromium'): 
+    elif (options.renderer == 'chrome') or (options.renderer == 'chromium'):
         cmd_parameters =  [ craft_bin_path(options),
                             '--allow-running-insecure-content',
                             '--ignore-certificate-errors',
@@ -400,88 +399,88 @@ def craft_cmd(url_and_options):
                             '--window-size=%s' % options.window_size,
                             '%s' % craft_arg(url) ]
         cmd_parameters.append('--proxy-server=%s' % options.proxy) if options.proxy != None else None
-    
+
     # Firefox renderer
-    elif options.renderer == 'firefox': 
+    elif options.renderer == 'firefox':
         cmd_parameters =  [ craft_bin_path(options),
                             '--new-instance',
                             '--screenshot=%s' % craft_arg(output_filename),
                             '--window-size=%s' % options.window_size,
                             '%s' % craft_arg(url) ]
-                            
+
     cmd = " ".join(cmd_parameters)
-    
+
     logger_url.debug("Shell command to be executed\n'%s'\n" % cmd)
-    
+
     execution_retval = shell_exec(url, cmd, options)
-    
+
     return execution_retval, url
 
-    
+
 def take_screenshot(url_list, options):
     """
         Launch the screenshot workers
         Thanks http://noswap.com/blog/python-multiprocessing-keyboardinterrupt
     """
     global SHELL_EXECUTION_OK, SHELL_EXECUTION_ERROR
-    
+
     screenshot_number = len(url_list)
     print("[+] %s URLs to be screenshot" % screenshot_number)
-    
+
     pool = multiprocessing.Pool(processes=int(options.workers), initializer=init_worker)
-    
+
     taken_screenshots = [r for r in pool.imap(func=craft_cmd, iterable=izip(url_list, itertools.repeat(options)))]
 
     screenshots_error_url = [url for retval, url in taken_screenshots if retval == SHELL_EXECUTION_ERROR]
     screenshots_error = sum(retval == SHELL_EXECUTION_ERROR for retval, url in taken_screenshots)
     screenshots_ok = int(screenshot_number - screenshots_error)
-    
+
     print("[+] %s actual URLs screenshot" % screenshots_ok)
     print("[+] %s error(s)" % screenshots_error)
-    
+
     if screenshots_error != 0:
         for url in screenshots_error_url:
             print("    %s" % url)
 
     return None
-    
+
 def main():
     """
         Dat main
     """
     global VERSION, SCREENSHOTS_DIRECTORY, LOGLEVELS
     signal.signal(signal.SIGINT, kill_em_all)
-    
+
     print('webscreenshot.py version %s\n' % VERSION)
-    
+
     options = parser.parse_args()
-    
+
     try :
         options.log_level = LOGLEVELS[options.verbosity]
         logger_gen.setLevel(options.log_level)
     except :
         parser.error("Please specify a valid log level")
-        
+
     if (options.input_file == None) and (options.URL == None):
         parser.error('Please specify a valid input file or a valid URL')
-    
+
     if (options.input_file != None) and (options.URL != None):
         parser.error('Please specify either an input file or an URL')
-    
+
     if options.output_directory != None:
         options.output_directory = os.path.join(os_getcwd(), options.output_directory)
     else:
         options.output_directory = SCREENSHOTS_DIRECTORY
-    
+
     logger_gen.debug("Options: %s\n" % options)
     if not os.path.exists(options.output_directory):
         logger_gen.info("'%s' does not exist, will then be created" % options.output_directory)
         os.makedirs(options.output_directory)
-        
+
     url_list = parse_targets(options)
-    
+
     take_screenshot(url_list, options)
-    
+
     return None
 
 if __name__ == "__main__" :


### PR DESCRIPTION
This pull request adds support for user-specified output image **format** and **quality**: PhantomJS already supports this, so it was only a matter of passing it the correct parameters.

Two optional arguments have been added to the Python main driver:
- `--format`, will accept any of the supported formats `pdf, png, jpg, jpeg, bmp, ppm`, defaults to `png`
- `--quality`, will accept any integer in the range `[0, 100]`, defaults to `70`

The default file format has **not** changed and it's still `png`, this to avoid breaking other tools that may be based on `webscreenshot`.

By simply switching to `jpg` and making use of the default quality at 70, the space being used by hundred of images will now decrease up to ~70% in my tests, sometimes even higher (ie. 50 screenshots, `png` size is ~42Mb, `jpg` size is ~10Mb - Yahoo homepage, `png` size if 1.8Mb, `jpg` size is 400Kb).