### PR TITLE
FIX multiprocessing memory bug

### DIFF
--- a/webscreenshot.py
+++ b/webscreenshot.py
@@ -515,6 +515,8 @@ def take_screenshot(url_list, options):
     print("[+] %s actual URLs screenshot" % screenshots_ok)
     print("[+] %s error(s)" % screenshots_error)
     
+    pool.close()
+
     if screenshots_error != 0:
         for url in screenshots_error_url:
             print("    %s" % url)

--- a/webscreenshot.py
+++ b/webscreenshot.py
@@ -516,6 +516,7 @@ def take_screenshot(url_list, options):
     print("[+] %s error(s)" % screenshots_error)
     
     pool.close()
+    pool.join()
 
     if screenshots_error != 0:
         for url in screenshots_error_url:


### PR DESCRIPTION
I found a bug using take_screenshot as a function in webscreenshot.py
The program I made It's a simple program that takes a screenshot and takes a screenshot.
Using the function as a daemon process, I found that the memory is not freed and continues to grow.
The bug was caused by not closing the pool in webscreenshot.py

Thank you for making the program.