### PR TITLE
Add --proxy-type functionality for Chrome/Chromium renderers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Options not listed here below are supported by every current renderer
 | **Connection parameters** |                                                                              |                        |                                |                      |
 |                       | proxy (`-P`)                                                                   | **Yes**                    | **Yes**                            | No                   |
 |                       | proxy_auth (`-A`)                                                              | **Yes**                    | No                             | No                   |
-|                       | proxy_type (`-T`)                                                              | **Yes**                    | No                             | No                   |
+|                       | proxy_type (`-T`)                                                              | **Yes**                    | **Yes**                             | No                   |
 |                       |                                                                              |                        |                                |                      |
 |                       | Ability to screenshot a HTTPS website with a non-publicly-signed certificate | **Yes**                    | No                             | No                   |
   

--- a/webscreenshot.py
+++ b/webscreenshot.py
@@ -479,9 +479,16 @@ def craft_cmd(url_and_options):
                             '--hide-scrollbars',
                             '--incognito',
                             '-screenshot=%s' % craft_arg(output_filename),
-                            '--window-size=%s' % options.window_size,
-                            '%s' % craft_arg(url) ]
-        cmd_parameters.append('--proxy-server=%s' % options.proxy) if options.proxy != None else None
+                            '--window-size=%s' % options.window_size]
+
+        # Add the proxy server full argument. Ex: --proxy-server="socks5://127.0.0.1:8080"
+        if options.proxy != None:
+            proxyArg = '--proxy-server="'
+            proxyArg += '%s://' % options.proxy_type if options.proxy_type != None else ''
+            proxyArg += '%s"' % options.proxy
+            cmd_parameters.append(proxyArg)
+
+        cmd_parameters.append('%s' % craft_arg(url))
     
     # Firefox renderer
     elif options.renderer == 'firefox': 


### PR DESCRIPTION
# Proposed change
Add some code that allows you to specify the type of proxy to use with the Chrome/Chromium renderer.

# Fixes
It prevents the error shown below when using a socks proxy with the Chrome/Chromium renderer:

![Chromium](https://raw.githubusercontent.com/zonicdoe/resources/master/webscreenshot/http_z.com_80.png "Proxy type error in Chromium")