### PR TITLE
Added Devtools protocol support for Chromium based browsers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Features
 * Mapping useful options of PhantomJS such as ignoring ssl error, proxy definition and proxy authentication, HTTP Basic Authentication
 * Supports multiple renderers: 
   * **PhantomJS**, which is legacy and [abandoned](https://groups.google.com/forum/#!topic/phantomjs/9aI5d-LDuNE) but the one still producing the best results
-  * **Chromium, Chrome and Edge Chromium**, which will replace PhantomJS but currently have some limitations: screenshoting an HTTPS website not having a valid certificate, for instance a self-signed one, will produce an empty screenshot.  
-    The reason is that the [`--ignore-certificate-errors`](https://groups.google.com/a/chromium.org/forum/#!topic/headless-dev/eiudRsYdc3A) option doesn't work and will never work anymore: the solution is to use a [proper webdriver](https://bugs.chromium.org/p/chromium/issues/detail?id=697721), but to date `webscreenshot` doesn't aim to support this _rather complex_ method requiring some third-party tools.
+  * **Chromium, Chrome and Edge Chromium**, which will replace PhantomJS
   * **Firefox** can also be used as a renderer but has some serious limitations (_so don't use it for the moment_):
     * Impossibility to perform multiple screenshots at the time: no multi-instance of the firefox process
     * No incognito mode, using webscreenshot will pollute your browsing history
@@ -36,7 +35,7 @@ domain_or_ip(/resource)
 
 ### Options
 ```
-webscreenshot.py version 2.8
+webscreenshot.py version 2.91
 
 usage: webscreenshot.py [-h] [-i INPUT_FILE] [-o OUTPUT_DIRECTORY]
                         [-w WORKERS] [-v] [-p PORT] [-s] [-m]
@@ -44,6 +43,7 @@ usage: webscreenshot.py [-h] [-i INPUT_FILE] [-o OUTPUT_DIRECTORY]
                         [--renderer-binary RENDERER_BINARY] [--no-xserver]
                         [--window-size WINDOW_SIZE]
                         [-f {pdf,png,jpg,jpeg,bmp,ppm}] [-q [0-100]]
+                        [-d DELAY_SECONDS]
                         [--ajax-max-timeouts AJAX_MAX_TIMEOUTS] [--crop CROP]
                         [-l] [--label-size LABEL_SIZE]
                         [--label-bg-color LABEL_BG_COLOR]
@@ -95,21 +95,25 @@ Screenshot image parameters:
                         <WINDOW_SIZE> (optional): width and height of the
                         screen capture (default '1200,800')
   -f {pdf,png,jpg,jpeg,bmp,ppm}, --format {pdf,png,jpg,jpeg,bmp,ppm}
-                        <FORMAT> (optional, phantomjs only): specify an output
-                        image file format, "pdf", "png", "jpg", "jpeg", "bmp"
-                        or "ppm" (default 'png')
+                        <FORMAT> (optional): specify an output image file
+                        format, Supported formats: PhantomJS -> "pdf", "png",
+                        "jpg", "jpeg", "bmp" or "ppm". ChromX -> "pdf", "jpg",
+                        "jpeg", or "png". (default 'png')
   -q [0-100], --quality [0-100]
-                        <QUALITY> (optional, phantomjs only): specify the
-                        output image quality, an integer between 0 and 100
-                        (default 75)
+                        <QUALITY> (optional, Phantomjs and ChromX[only JPEG
+                        format]): specify the output image quality, an integer
+                        between 0 and 100 (default 75)
+  -d DELAY_SECONDS, --delay DELAY_SECONDS
+                        <DELAY> (optional, ChromX only): specify a screen
+                        capture delay in seconds (default 0)
   --ajax-max-timeouts AJAX_MAX_TIMEOUTS
                         <AJAX_MAX_TIMEOUTS> (optional, phantomjs only): per
                         AJAX request, and max URL timeout in milliseconds
                         (default '1400,1800')
-  --crop CROP           <CROP> (optional, phantomjs only): rectangle <t,l,w,h>
-                        to crop the screen capture to (default to WINDOW_SIZE:
-                        '0,0,w,h'), only numbers, w(idth) and h(eight). Ex.
-                        "10,20,w,h"
+  --crop CROP           <CROP> (optional, phantomjs and ChromeX): rectangle
+                        <t,l,w,h> to crop the screen capture to (default to
+                        WINDOW_SIZE: '0,0,w,h'), only numbers, w(idth) and
+                        h(eight). Ex. "10,20,w,h"
 
 Screenshot label parameters:
   -l, --label           <LABEL> (optional): for each screenshot, create
@@ -229,14 +233,14 @@ Options not listed here below are supported by every current renderer
 | **Option category**   | **Option**                                                                   | **PhantomJS renderer** | **Chromium / Chrome / Edge Chromium renderer** | **Firefox renderer** |
 |:---------------------:|------------------------------------------------------------------------------|:----------------------:|:------------------------------:|:--------------------:|
 | **Screenshot parameters**   |                                                                              |                        |                                |                      |
-|                       | format (`-f`)                                                                  | [**Yes**](https://web.archive.org/web/20200111184123/https://phantomjs.org/api/webpage/method/render.html)                    | No                             | No                   |
-|                       | quality (`-q`)                                                                  | [**Yes**](https://web.archive.org/web/20200111184123/https://phantomjs.org/api/webpage/method/render.html)                    | No                             | No                   
+|                       | format (`-f`)                                                                  | [**Yes**](https://web.archive.org/web/20200111184123/https://phantomjs.org/api/webpage/method/render.html)                    | [**Yes**](https://chromedevtools.github.io/devtools-protocol/1-3/Page/#method-captureScreenshot)                             | No                   |
+|                       | quality (`-q`)                                                                  | [**Yes**](https://web.archive.org/web/20200111184123/https://phantomjs.org/api/webpage/method/render.html)                    | [**Yes**](https://chromedevtools.github.io/devtools-protocol/1-3/Page/#method-captureScreenshot)                             | No                   
 |                       | ajax and request timeouts (`--ajax-max-timeouts`)                                         | **Yes**                    | No                             | No                   
-|                       | crop (`--crop`)                                                                  | [**Yes**](https://web.archive.org/web/20200111184050/https://phantomjs.org/api/webpage/property/clip-rect.html)                    | No                             | No                   
+|                       | crop (`--crop`)                                                                  | [**Yes**](https://web.archive.org/web/20200111184050/https://phantomjs.org/api/webpage/property/clip-rect.html)                    | [**Yes**](https://chromedevtools.github.io/devtools-protocol/1-3/Page/#type-Viewport)                             | No                   
 |                       |                                                                              |                        |                                |                      |
 | **HTTP parameters**   |                                                                              |                        |                                |                      |
-|                       | cookie (`-c`)                                                                  | **Yes**                    | No                             | No                   |
-|                       | header (`-a`)                                                                  | **Yes**                    | No                             | No                   |
+|                       | cookie (`-c`)                                                                  | **Yes**                    | [**Yes**](https://chromedevtools.github.io/devtools-protocol/1-3/Network/#method-setCookies)                             | No                   |
+|                       | header (`-a`)                                                                  | **Yes**                    | [**Yes**](https://chromedevtools.github.io/devtools-protocol/1-3/Network/#method-setExtraHTTPHeaders)                             | No                   |
 |                       | http_username (`-u`)                                                           | **Yes**                    | No                             | No                   |
 |                       | http_password (`-b`)                                                           | **Yes**                    | No                             | No                   |
 |                       |                                                                              |                        |                                |                      |
@@ -245,12 +249,12 @@ Options not listed here below are supported by every current renderer
 |                       | proxy_auth (`-A`)                                                              | **Yes**                    | No                             | No                   |
 |                       | proxy_type (`-T`)                                                              | **Yes**                    | [**Yes**](https://github.com/maaaaz/webscreenshot/pull/51)                             | No                   |
 |                       |                                                                              |                        |                                |                      |
-|                       | Ability to screenshot a HTTPS website with a non-publicly-signed certificate | **Yes**                    | No                             | No                   |
+|                       | Ability to screenshot a HTTPS website with a non-publicly-signed certificate | **Yes**                    | Not tested yet                             | No                   |
   
   
 Requirements
 ------------
-* A Python interpreter with version 2.7 or 3.X
+* A Python interpreter with version >= 3.6.1
 * The webscreenshot python script: 
   * The **easiest way** to setup it: `pip install webscreenshot` and then directly use `$ webscreenshot` 
   * Or git clone that repository and `pip install -r requirements.txt` and then `python webscreenshot.py`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 future
 argparse
+websockets

--- a/webscreenshot.py
+++ b/webscreenshot.py
@@ -37,6 +37,10 @@ import logging
 import errno
 import argparse
 import base64
+import requests
+import json
+import asyncio
+import websockets
 
 # Python 2 and 3 compatibility
 if (sys.version_info < (3, 0)):
@@ -72,10 +76,11 @@ renderer_grp.add_argument('--no-xserver', help = '<NO_X_SERVER> (optional): if y
 
 image_grp = parser.add_argument_group('Screenshot image parameters')
 image_grp.add_argument('--window-size', help = '<WINDOW_SIZE> (optional): width and height of the screen capture (default \'1200,800\')', default = '1200,800')
-image_grp.add_argument('-f', '--format', help = '<FORMAT> (optional, phantomjs only): specify an output image file format, "pdf", "png", "jpg", "jpeg", "bmp" or "ppm" (default \'png\')', choices = ['pdf', 'png', 'jpg', 'jpeg', 'bmp', 'ppm'], type=str.lower, default = 'png')
-image_grp.add_argument('-q', '--quality', help = '<QUALITY> (optional, phantomjs only): specify the output image quality, an integer between 0 and 100 (default 75)', metavar="[0-100]", choices = range(0,101), type = int, default = 75)
+image_grp.add_argument('-f', '--format', help = '<FORMAT> (optional): specify an output image file format, Supported formats: PhantomJS -> "pdf", "png", "jpg", "jpeg", "bmp" or "ppm". ChromX -> "pdf", "jpg", "jpeg", or "png". (default \'png\')', choices = ['pdf', 'png', 'jpg', 'jpeg', 'bmp', 'ppm'], type=str.lower, default = 'png')
+image_grp.add_argument('-q', '--quality', help = '<QUALITY> (optional, Phantomjs and ChromX[only JPEG format]): specify the output image quality, an integer between 0 and 100 (default 75)', metavar="[0-100]", choices = range(0,101), type = int, default = 75)
+image_grp.add_argument('-d', '--delay', help = '<DELAY> (optional, ChromX only): specify a screen capture delay in seconds (default 0)', metavar="DELAY_SECONDS", type = int, default = 0)
 image_grp.add_argument('--ajax-max-timeouts', help = '<AJAX_MAX_TIMEOUTS> (optional, phantomjs only): per AJAX request, and max URL timeout in milliseconds (default \'1400,1800\')', default = '1400,1800')
-image_grp.add_argument('--crop', help = '<CROP> (optional, phantomjs only): rectangle <t,l,w,h> to crop the screen capture to (default to WINDOW_SIZE: \'0,0,w,h\'), only numbers, w(idth) and h(eight). Ex. "10,20,w,h"')
+image_grp.add_argument('--crop', help = '<CROP> (optional, phantomjs and ChromeX): rectangle <t,l,w,h> to crop the screen capture to (default to WINDOW_SIZE: \'0,0,w,h\'), only numbers, w(idth) and h(eight). Ex. "10,20,w,h"')
 
 image_grp = parser.add_argument_group('Screenshot label parameters')
 image_grp.add_argument('-l', '--label', help = '<LABEL> (optional): for each screenshot, create another one displaying inside the target URL (requires imagemagick)', action = 'store_true', default = False)
@@ -108,6 +113,11 @@ IMAGEMAGICK_BIN = "convert"
 WEBSCREENSHOT_JS = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), './webscreenshot.js'))
 SCREENSHOTS_DIRECTORY = os.path.abspath(os.path.join(os_getcwd(), './screenshots/'))
 
+# Default devtools server (localhost).
+# Used to run Chrome based browsers in remote debugging mode:
+DEVTOOLS_SERVER = "http://127.0.0.1"
+DEVTOOLS_PORT = 9222  # Change if it conflicts with another running service
+
 # Logger definition
 LOGLEVELS = {0 : 'ERROR', 1 : 'INFO', 2 : 'DEBUG'}
 logger_output = logging.StreamHandler(sys.stdout)
@@ -120,12 +130,16 @@ logger_gen.addHandler(logger_output)
 SHELL_EXECUTION_OK = 0
 SHELL_EXECUTION_ERROR = -1
 PHANTOMJS_HTTP_AUTH_ERROR_CODE = 2
+CHROMX_RENDER_TIMOUT_ERROR = 3
+CHROMX_CONNECTION_ERROR = 4
+CHROMX_OUTPUT_FILE_ERROR = 5
 
 # Handful patterns
 p_ipv4_elementary = '(?:[\d]{1,3})\.(?:[\d]{1,3})\.(?:[\d]{1,3})\.(?:[\d]{1,3})'
 p_domain = '[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]+'
 p_port = '\d{0,5}'
 p_resource = '(?:/(?P<res>.*))?'
+p_cookies = re.compile(r'[\s]?([^=]+)=([^;\s]+)[;]?', re.I)
 
 full_uri_domain = re.compile('^(?P<protocol>http(?:|s))://(?P<host>%s|%s)(?::(?P<port>%s))?%s$' % (p_domain, p_ipv4_elementary, p_port, p_resource))
 
@@ -143,6 +157,48 @@ def is_windows():
         Are we running on Windows or not ?
     """
     return "win32" in sys.platform.lower()
+
+def getWebSocketData():
+    """
+        Get Browser's control websocket URL and Tab ID.
+    """
+    # returned data:
+    result = {
+        "code": "OK",
+        "message": "",
+        "WS": None,
+        "tabID": None
+    }
+
+    try:
+        # Request Browser's available pages and websockets (0.5 seconds timeout):
+        response = requests.get("%s:%d/json/list" % (DEVTOOLS_SERVER, DEVTOOLS_PORT), timeout=0.5)
+    except (
+        requests.exceptions.ConnectTimeout,
+        requests.exceptions.ConnectionError,
+        requests.exceptions.InvalidURL,
+        requests.exceptions.ReadTimeout
+    ) as e:
+        result["code"] = "ERROR"
+        result["message"] = str(e)
+        return result
+
+    try:
+        # Parse JSON response:
+        data = json.loads(response.text)
+    except (json.decoder.JSONDecodeError) as e:
+        result["code"] = "ERROR"
+        result["message"] = str(e)
+        return result
+
+    # In case that additional items are present in the browser
+    # (like the devtools window), pick the page asociated to the URL:
+    for tab in data:
+        if tab["url"] == "http://127.0.0.1/?id=debugger":
+            result["WS"] = tab["webSocketDebuggerUrl"]
+            result["tabID"] = tab["id"]
+            break
+    return result
 
 def init_worker():
     """ 
@@ -237,6 +293,87 @@ def shell_exec(url, command, options, context):
     except Exception as err:
         logger_gen.error('Unknown error: %s, exiting' % err)
         return SHELL_EXECUTION_ERROR
+
+def chromx_debugger_exec(options):
+    """
+        Execute ChromX browser in headless-remote debugging mode (Devtools protocol).
+        When executed this way, the ChromX browser will start a server listening on the specified port.
+        The most important endpoints of this server are:
+        /json/close/{tabId} -> instructs the browser to close the specified tab.
+        /json or /json/list -> returns a list of all available websocket targets.
+                               Every tab has its own websocket URL in which it can
+                               receive commands via JSON payloads.
+        /json/new?{url} -> instructs the browser to open a new tab (url is optional).
+                           It returns a JSON object containing the tab ID and websocket URL,
+                           among other data.
+
+        As mentioned before, every tab has its own websocket URL, in which the script can send commands.
+        The complete list of supported commands can be found at:
+        https://chromedevtools.github.io/devtools-protocol/
+        The basic structure of a valid JSON payload is the following:
+        {
+            "id": 0, # An ID integer, it can be any integer.
+                     # It's mainly used to associate a server response with a previous request.
+            "method": <DEVTOOLS_PROTOCOL_DOMAIN.COMMAND>, # String, Ex. "Page.captureScreenshot"
+            "params": { # The parameters that the command requires
+                "paramX": value1,
+                "paramY": value2,
+                ...
+            }
+        }
+    """
+    cmd_parameters = [
+        craft_bin_path(options),
+        '--allow-running-insecure-content',
+        # The following flag will be reforced via Devtools protocol
+        # in the screenshot process, in case it's no longer supported
+        # by the current browser:
+        '--ignore-certificate-errors',
+        '--ignore-urlfetcher-cert-requests',
+        '--reduce-security-for-testing',
+        '--headless',
+        '--disable-gpu',
+        '--hide-scrollbars',
+        '--incognito',
+        '--user-data-dir=.tmp',  # Work around to spawn an independant instance
+        '--remote-debugging-port=%d' % DEVTOOLS_PORT,  # Devtools server's listening port
+        '--window-size=%s' % options.window_size,
+        '%s' % craft_arg('http://127.0.0.1/?id=debugger')
+    ]
+    cmd_parameters.append('--proxy-server=%s' % options.proxy) if options.proxy is not None else None
+    command = " ".join(cmd_parameters)
+    logger_gen.debug("Shell command to be executed\n'%s'\n" % command)
+
+    def group_subprocesses():
+        if options.no_xserver and not(is_windows()):
+            os.setsid()
+
+    try:
+        if is_windows():
+            p = subprocess.Popen(shlex.split(command, posix=not(is_windows())), shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        else:
+            p = subprocess.Popen(shlex.split(command, posix=not(is_windows())), shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, preexec_fn=group_subprocesses)
+    except OSError as e:
+        if e.errno and e.errno == errno.ENOENT:
+            logger_gen.error('%s binary could not have been found in your current PATH environment variable, exiting' % 'renderer')
+            return SHELL_EXECUTION_ERROR
+
+    except Exception as err:
+        logger_gen.error('Unknown error: %s, exiting' % err)
+        return SHELL_EXECUTION_ERROR
+
+async def chromx_terminate(wsserver):
+    """
+        Kills the Devtools server.
+    """
+    async with websockets.connect(wsserver) as websocket:
+        raw = {
+            "id": 1,
+            "method": "Browser.close",
+            "params": {}
+        }
+        request = json.dumps(raw)
+        await websocket.send(request)
 
 def filter_bad_filename_chars(filename):
     """
@@ -395,6 +532,136 @@ def craft_arg(param):
     else:
         return '"%s"' % param
 
+def launch_cromx_subprocess(logger, url, options):
+    """
+        For ChromX browsers.
+        Load a new target URL and trigger the screenshot process.
+    """
+
+    # Not an acutal "instance", but a new tab:
+    logger.debug("Openning new browser instance")
+    try:
+        # Load new Chromx tab:
+        response = requests.get("%s:%d/json/new" % (DEVTOOLS_SERVER, DEVTOOLS_PORT))
+    except (
+        requests.exceptions.ConnectTimeout,
+        requests.exceptions.ConnectionError,
+        requests.exceptions.InvalidURL,
+        requests.exceptions.ReadTimeout
+    ) as e:
+        logger.error("Failed to spawn a new browser instance : %s" % str(e))
+        return SHELL_EXECUTION_ERROR
+
+    if response.status_code == 200:
+        try:
+            # Get some data (websocket URL, tab ID) of the browser tab asociated with the current worker.
+            # Every tab has its own websocket URL (webSocketDebuggerUrl),
+            # as defined in https://chromedevtools.github.io/devtools-protocol/
+            tabData = json.loads(response.text)
+        except (json.decoder.JSONDecodeError) as e:
+            logger.error("Failed to parse Devtools server response: %s" % str(e))
+            return SHELL_EXECUTION_ERROR
+
+        logger.debug('Tab\'s websocket: %s' % tabData['webSocketDebuggerUrl'])
+
+        output_format = None  # Output file format
+        timeout = int(options.timeout)  # Screenshot timeout
+        headers = {}  # User defined headers
+        cookies = []  # User defined cookies
+        # Screen capture region defaults, overriden by user defined "crop" parameter:
+        region = [
+            "0",  # Top offset (in pixels)
+            "0",  # Left offset (in pixels)
+            options.window_size.split(',')[0],  # Screen capture region width (in pixels)
+            "0"  # Screen capture region height  (in pixels, 0 will capture full page)
+        ]
+
+        # Additional HTTP headers:
+        if options.header:
+            for header in options.header:
+                raw_header = header.rstrip(';').split(': ')
+                headers[raw_header[0]] = raw_header[1]
+
+        # Cookies:
+        if options.cookie is not None:
+            raw_cookies = re.findall(p_cookies, options.cookie)
+            expires = int(time.time()) + timeout + 60
+            for cookie in raw_cookies:
+                cookies.append(
+                    {
+                        "name": cookie[0],
+                        "value": cookie[1],
+                        "url": url,
+                        "expires": expires
+                    }
+                )
+
+        # Screeenshot format (JPEG, PNG or PDF), as described at:
+        # https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot
+        # https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF
+        if options.format == 'png' or options.format == 'jpeg' or options.format == 'pdf':
+            output_format = options.format
+        elif options.format == "jpg":
+            output_format = "jpeg"
+        else:  # User choose a valid format, but not one supported by ChromX
+            output_format = "png"  # Default format
+            logger.info("%s format is not supported by the renderer, setting default instead (PNG)." % options.format.upper())
+
+        # Screenshot file:
+        output_filename = os.path.join(options.output_directory, ('%s.%s' % (filter_bad_filename_chars(url), output_format)))
+
+        # Screen capture region (overrides default):
+        if options.crop is not None:
+            crop_option = options.crop.replace(
+                'w', options.window_size.split(',')[0]
+            ).replace(
+                'h', options.window_size.split(',')[1]
+            )
+
+            region = crop_option.split(',')
+
+        # Screenshot process.
+        retval = asyncio.get_event_loop().run_until_complete(
+            chromx_screenshot(
+                logger=logger,
+                tabID=tabData["id"],
+                wsserver=tabData["webSocketDebuggerUrl"],
+                URL=url,
+                headers=headers,
+                cookies=cookies,
+                path=output_filename,
+                format=output_format,
+                quality=options.quality,
+                width=int(region[2]),
+                height=int(region[3]),
+                top=int(region[0]),
+                left=int(region[1]),
+                delay=options.delay,
+                timeout=timeout
+            )
+        )
+
+        # ChromX errors go here:
+        if retval != SHELL_EXECUTION_OK:
+            if retval == CHROMX_RENDER_TIMOUT_ERROR:
+                # Render timout
+                logger.debug("Tab %s reached the timeout, it has been killed." % tabData["id"])
+                logger.error("Screenshot somehow failed.\n")
+            elif retval == CHROMX_CONNECTION_ERROR:
+                logger.debug("Tab %s's websocket is not responding, it has been killed." % tabData["id"])
+                logger.error("Screenshot somehow failed.\n")
+            elif retval == CHROMX_OUTPUT_FILE_ERROR:
+                logger.debug("An error ocurred while saving screenshot file.")
+                logger.error("Screenshot somehow failed.\n")
+            return SHELL_EXECUTION_ERROR
+        else:
+            logger.debug("Tab %s ended normally." % tabData["id"])
+            logger.info("Screenshot OK.\n")
+            return SHELL_EXECUTION_OK
+    else:
+        logger.error("Failed to spawn a new browser instance [Devtools server responded with status code: %d]." % response.status_code)
+        return SHELL_EXECUTION_ERROR
+
 def launch_cmd(logguer, url, cmd_parameters, options, context):
     """
         Launch the actual command
@@ -419,78 +686,65 @@ def craft_cmd(url_and_options):
     
     output_format = options.format if options.renderer == 'phantomjs' else 'png'
     output_filename = os.path.join(options.output_directory, ('%s.%s' % (filter_bad_filename_chars(url), output_format)))
-        
-    # PhantomJS renderer
-    if options.renderer == 'phantomjs':
-        # If you ever want to add some voodoo options to the phantomjs command to be executed, that's here right below
-        cmd_parameters = [ craft_bin_path(options),
-                           '--ignore-ssl-errors=true',
-                           '--ssl-protocol=any',
-                           '--ssl-ciphers=ALL' ]
-        
-        cmd_parameters.append("--proxy %s" % options.proxy) if options.proxy != None else None
-        cmd_parameters.append("--proxy-auth %s" % options.proxy_auth) if options.proxy_auth != None else None
-        cmd_parameters.append("--proxy-type %s" % options.proxy_type) if options.proxy_type != None else None
 
-        cmd_parameters.append('%s url_capture=%s output_file=%s' % (craft_arg(WEBSCREENSHOT_JS), url, craft_arg(output_filename)))
-        
-        cmd_parameters.append('header="Cookie: %s"' % options.cookie.rstrip(';')) if options.cookie != None else None
-        
-        if options.http_username != None:
-            if options.http_password != None:
-                basic_authentication_header = base64.b64encode(str("%s:%s" % (options.http_username, options.http_password)).encode()).decode()
+    # ChromX renderers:
+    if (options.renderer == 'chrome') or (options.renderer == 'chromium'):
+        execution_retval = launch_cromx_subprocess(logger_url, url, options)
+    else:
+        # PhantomJS renderer
+        if options.renderer == 'phantomjs':
+            # If you ever want to add some voodoo options to the phantomjs command to be executed, that's here right below
+            cmd_parameters = [ craft_bin_path(options),
+                               '--ignore-ssl-errors=true',
+                               '--ssl-protocol=any',
+                               '--ssl-ciphers=ALL' ]
             
-            else:
-                basic_authentication_header = base64.b64encode(str("%s:" % (options.http_username)).encode()).decode()
+            cmd_parameters.append("--proxy %s" % options.proxy) if options.proxy != None else None
+            cmd_parameters.append("--proxy-auth %s" % options.proxy_auth) if options.proxy_auth != None else None
+            cmd_parameters.append("--proxy-type %s" % options.proxy_type) if options.proxy_type != None else None
+
+            cmd_parameters.append('%s url_capture=%s output_file=%s' % (craft_arg(WEBSCREENSHOT_JS), url, craft_arg(output_filename)))
             
-            cmd_parameters.append('header="Authorization: Basic %s"' % basic_authentication_header)
-        
-        width = options.window_size.split(',')[0]
-        
-        height = options.window_size.split(',')[1]
-        cmd_parameters.append('width=%d' % int(width))
-        cmd_parameters.append('height=%d' % int(height))
-        
-        cmd_parameters.append('format=%s' % options.format)
-        cmd_parameters.append('quality=%d' % int(options.quality))
-        
-        cmd_parameters.append('ajaxtimeout=%d' % int(options.ajax_max_timeouts.split(',')[0]))
-        cmd_parameters.append('maxtimeout=%d' % int(options.ajax_max_timeouts.split(',')[1]))
-        
-        if options.crop != None:
-            crop_rectangle = options.crop.replace('w', width).replace('h', height)
-            cmd_parameters.append('crop="%s"' % crop_rectangle)
-        
-        if options.header:
-            for header in options.header:
-                cmd_parameters.append('header="%s"' % header.rstrip(';'))
-    
-    # Chrome and chromium renderers
-    elif (options.renderer == 'chrome') or (options.renderer == 'chromium'): 
-        cmd_parameters =  [ craft_bin_path(options),
-                            '--allow-running-insecure-content',
-                            '--ignore-certificate-errors',
-                            '--ignore-urlfetcher-cert-requests',
-                            '--reduce-security-for-testing',
-                            '--no-sandbox',
-                            '--headless',
-                            '--disable-gpu',
-                            '--hide-scrollbars',
-                            '--incognito',
-                            '-screenshot=%s' % craft_arg(output_filename),
-                            '--window-size=%s' % options.window_size,
-                            '%s' % craft_arg(url) ]
-        cmd_parameters.append('--proxy-server=%s' % options.proxy) if options.proxy != None else None
-    
-    # Firefox renderer
-    elif options.renderer == 'firefox': 
-        cmd_parameters =  [ craft_bin_path(options),
-                            '--new-instance',
-                            '--screenshot=%s' % craft_arg(output_filename),
-                            '--window-size=%s' % options.window_size,
-                            '%s' % craft_arg(url) ]
-                            
-    execution_retval = launch_cmd(logger_url, url, cmd_parameters, options, 'renderer')
+            cmd_parameters.append('header="Cookie: %s"' % options.cookie.rstrip(';')) if options.cookie != None else None
+            
+            if options.http_username != None:
+                if options.http_password != None:
+                    basic_authentication_header = base64.b64encode(str("%s:%s" % (options.http_username, options.http_password)).encode()).decode()
+                
+                else:
+                    basic_authentication_header = base64.b64encode(str("%s:" % (options.http_username)).encode()).decode()
+                
+                cmd_parameters.append('header="Authorization: Basic %s"' % basic_authentication_header)
+            
+            width = options.window_size.split(',')[0]
+            
+            height = options.window_size.split(',')[1]
+            cmd_parameters.append('width=%d' % int(width))
+            cmd_parameters.append('height=%d' % int(height))
+            
+            cmd_parameters.append('format=%s' % options.format)
+            cmd_parameters.append('quality=%d' % int(options.quality))
+            
+            cmd_parameters.append('ajaxtimeout=%d' % int(options.ajax_max_timeouts.split(',')[0]))
+            cmd_parameters.append('maxtimeout=%d' % int(options.ajax_max_timeouts.split(',')[1]))
+            
+            if options.crop != None:
+                crop_rectangle = options.crop.replace('w', width).replace('h', height)
+                cmd_parameters.append('crop="%s"' % crop_rectangle)
+            
+            if options.header:
+                for header in options.header:
+                    cmd_parameters.append('header="%s"' % header.rstrip(';'))
+
+        # Firefox renderer
+        elif options.renderer == 'firefox': 
+            cmd_parameters =  [ craft_bin_path(options),
+                                '--new-instance',
+                                '--screenshot=%s' % craft_arg(output_filename),
+                                '--window-size=%s' % options.window_size,
+                                '%s' % craft_arg(url) ]
+                                
+        execution_retval = launch_cmd(logger_url, url, cmd_parameters, options, 'renderer')
     
     # ImageMagick URL embedding
     if options.label and execution_retval == SHELL_EXECUTION_OK:
@@ -508,23 +762,321 @@ def craft_cmd(url_and_options):
     
     return execution_retval, url
 
-    
+async def chromx_screenshot(
+    logger,
+    tabID,
+    wsserver,
+    URL,  # Target URL
+    headers={},  # Additional HTTP headers
+    cookies=[],  # Cookies to inject into the request
+    path="screenshot.png",  # Image or PDF destination file
+    format="png",  # File format
+    quality=70,  # Image quality
+    width=1200,  # Screen capture region width
+    height=800,  # Screen capture region height
+    top=0,  # Sreen capture region top offset
+    left=0,  # Sreen capture region left offset
+    delay=0,
+    timeout=30
+):
+    """
+        Chromium based browsers screenshot
+        ( using Devtools protocol, more info at
+        https://chromedevtools.github.io/devtools-protocol/ )
+    """
+    async def main():
+        # Final screen capture region height:
+        finalHeight = height
+
+        async with websockets.client.connect(wsserver, ping_interval=None, close_timeout=60, max_size=None) as websocket:
+            # Reforce certificate error ignoring (Experimental):
+            # https://chromedevtools.github.io/devtools-protocol/tot/Security/#method-setIgnoreCertificateErrors
+            raw = {
+                "id": 1,
+                "method": "Security.setIgnoreCertificateErrors",
+                "params": {
+                    "ignore": True
+                }
+            }
+            request = json.dumps(raw)
+            await websocket.send(request)
+
+            # Enable Network tracking (used for setting HTTP headers and cookies):
+            # https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-enable
+            raw = {
+                "id": 10,
+                "method": "Network.enable",
+                "params": {}
+            }
+            request = json.dumps(raw)
+            await websocket.send(request)
+            logger.debug("Network tracking enabled.")
+
+            # Set extra headers:
+            # https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setExtraHTTPHeaders
+            if len(headers) > 0:
+                raw = {
+                    "id": 30,
+                    "method": "Network.setExtraHTTPHeaders",
+                    "params": {
+                        "headers": headers
+                    }
+                }
+                request = json.dumps(raw)
+                await websocket.send(request)
+
+            # Set Cookies:
+            # https://chromedevtools.github.io/devtools-protocol/1-3/Network/#method-setCookies
+            if len(cookies) > 0:
+                raw = {
+                    "id": 31,
+                    "method": "Network.setCookies",
+                    "params": {
+                        "cookies": cookies
+                    }
+                }
+                request = json.dumps(raw)
+                await websocket.send(request)
+
+            # Enable page domain notifications (used for determining when the page has been loaded):
+            # https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-enable
+            raw = {
+                "id": 20,
+                "method": "Page.enable",
+                "params": {}
+            }
+            request = json.dumps(raw)
+            await websocket.send(request)
+            logger.debug("Page domain notifications enabled.")
+
+            # Load target URL in the browser:
+            # https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-navigate
+            logger.debug("Loading URL.")
+            raw = {
+                "id": 40,
+                "method": "Page.navigate",
+                "params": {
+                    "url": URL,
+                }
+            }
+            request = json.dumps(raw)
+            await websocket.send(request)
+
+            # Wait for the page to load:
+            # https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-loadEventFired
+            while True:
+                response = await websocket.recv()
+                data = json.loads(response)
+                if "method" in data and data["method"] == "Page.loadEventFired":
+                    logger.debug("Page Ready.")
+                    break
+
+            # Disable Network tracking:
+            # https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-disable
+            raw = {
+                "id": 50,
+                "method": "Network.disable",
+                "params": {}
+            }
+            request = json.dumps(raw)
+            await websocket.send(request)
+            logger.debug("Network tracking disabled.")
+
+            # Default screen capture region height (full page):
+            if finalHeight == 0:
+                # Get page metrics for full page screenshot:
+                # https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-getLayoutMetrics
+                raw = {
+                    "id": 51,
+                    "method": "Page.getLayoutMetrics",
+                    "params": {}
+                }
+                request = json.dumps(raw)
+                await websocket.send(request)
+                logger.debug("Reading page layout metrics.")
+                # Wait for response data:
+                while True:
+                    response = await websocket.recv()
+                    data = json.loads(response)
+                    if "id" in data and data["id"] == 51:
+                        logger.debug("Page metrics: %dx%d px" % (data["result"]["contentSize"]["width"], data["result"]["contentSize"]["height"]))
+                        finalHeight = data["result"]["contentSize"]["height"]
+                        break
+
+            # Update viewport with the full page height:
+            # https://chromedevtools.github.io/devtools-protocol/1-3/Emulation/#method-setDeviceMetricsOverride
+            raw = {
+                "id": 52,
+                "method": "Emulation.setDeviceMetricsOverride",
+                "params": {
+                    "width": width,
+                    "height": finalHeight,
+                    "deviceScaleFactor": 1,  # 1 = 100%
+                    "mobile": False,
+                    "screenOrientation": {"angle": 0, "type": "portraitPrimary"}
+                }
+            }
+            request = json.dumps(raw)
+            await websocket.send(request)
+            logger.debug("Viewport updated for full page screenshot.")
+
+            # Disable page domain notifications:
+            raw = {
+                "id": 60,
+                "method": "Page.disable",
+                "params": {}
+            }
+            request = json.dumps(raw)
+            await websocket.send(request)
+            logger.debug("Page domain notifications disabled.")
+            # Wait for the screenshot data:
+
+            # Wait for the user defined screenshot delay:
+            if delay > 0:
+                logger.info("Waiting %s seconds before taking the screenshot...\n" % delay)
+            await asyncio.sleep(delay + 0.5)
+
+            # Take screeshot:
+            logger.debug("Taking screenshot.")
+            if format == "png" or format == "jpeg":
+                # Image file:
+                # https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot
+                raw = {
+                    "id": 70,
+                    "method": "Page.captureScreenshot",
+                    "params": {
+                        "format": format,  # JPEG or PNG
+                        "quality": quality,  # ignored if not JPEG
+                        "clip": {
+                            "x": left,  # Left offset
+                            "y": top,  # Top offset
+                            "width": width,  # Screen capture region width
+                            "height": finalHeight,  # Screen capture region height
+                            "scale": 1  # Scale factor (1 = 100%)
+                        }
+                    }
+                }
+                request = json.dumps(raw)
+                await websocket.send(request)
+
+            else:
+                # PDF file:
+                # https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF
+                # landscape                 boolean     (optional) Paper orientation. Defaults to false.
+                # displayHeaderFooter       boolean     (optional) Display header and footer. Defaults to false.
+                # printBackground           boolean     (optional) Print background graphics. Defaults to false.
+                # scale                     number      (optional) Scale of the webpage rendering. Defaults to 1.
+                # paperWidth                number      (optional) Paper width in inches. Defaults to 8.5 inches.
+                # paperHeight               number      (optional) Paper height in inches. Defaults to 11 inches.
+                # marginTop                 number      (optional) Top margin in inches. Defaults to 1cm (~0.4 inches).
+                # marginBottom              number      (optional) Bottom margin in inches. Defaults to 1cm (~0.4 inches).
+                # marginLeft                number      (optional) Left margin in inches. Defaults to 1cm (~0.4 inches).
+                # marginRight               number      (optional) Right margin in inches. Defaults to 1cm (~0.4 inches).
+                # pageRanges                string      (optional) Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
+                # ignoreInvalidPageRanges   boolean     (optional) Whether to silently ignore invalid but successfully parsed page ranges, such as '3-2'. Defaults to false.
+                # headerTemplate            string      (optional) HTML template for the print header. Should be valid HTML markup with following classes used to inject
+                #                                                       printing values into them:
+                #                                                       date: formatted print date
+                #                                                       title: document title
+                #                                                       url: document location
+                #                                                       pageNumber: current page number
+                #                                                       totalPages: total pages in the document
+                #                                                  For example, <span class=title></span> would generate span containing the title.
+                #
+                # footerTemplate            string      (optional) HTML template for the print footer. Should use the same format as the headerTemplate.
+                # preferCSSPageSize         boolean     (optional) Whether or not to prefer page size as defined by css. Defaults to false, in which case the content will be scaled to fit the paper size.
+                raw = {
+                    "id": 70,
+                    "method": "Page.printToPDF",
+                    "params": {
+                        "printBackground": True
+                    }
+                }
+                request = json.dumps(raw)
+                await websocket.send(request)
+
+            # Wait for the screenshot data:
+            while True:
+                response = await websocket.recv()
+                data = json.loads(response)
+                if "id" in data and data["id"] == 70:
+                    logger.debug("Screenshot ready: %s" % data['id'])
+                    break
+
+            # Save screenshot
+            try:
+                logger.debug("Saving screenshot: %s" % path)
+                content = base64.b64decode(data["result"]["data"])
+                f = open(path, 'wb')
+                f.write(content)
+                f.close()
+            except Exception as e:
+                logger.error(str(e))
+                return CHROMX_OUTPUT_FILE_ERROR
+
+            # Unload tab
+            response = requests.get("%s:%d/json/close/%s" % (DEVTOOLS_SERVER, DEVTOOLS_PORT, tabID))
+
+    try:
+        # Execute screenshot respecting the user defined timeout or default timeout:
+        await asyncio.wait_for(main(), timeout=timeout)
+        return SHELL_EXECUTION_OK
+    # Render timeout:
+    except asyncio.TimeoutError:
+        # Unload tab
+        requests.get("%s:%d/json/close/%s" % (DEVTOOLS_SERVER, DEVTOOLS_PORT, tabID))
+        return CHROMX_RENDER_TIMOUT_ERROR
+    except websockets.ConnectionClosedError:
+        # Unload tab
+        requests.get("%s:%d/json/close/%s" % (DEVTOOLS_SERVER, DEVTOOLS_PORT, tabID))
+        return CHROMX_CONNECTION_ERROR
+
 def take_screenshot(url_list, options):
     """
         Launch the screenshot workers
         Thanks http://noswap.com/blog/python-multiprocessing-keyboardinterrupt
     """
     global SHELL_EXECUTION_OK, SHELL_EXECUTION_ERROR
-    
+    # Stores the Devtools server main websocket URL
+    browserControler = None
+
     screenshot_number = len(url_list)
     print("[+] %s URLs to be screenshot" % screenshot_number)
     
     pool = multiprocessing.Pool(processes=int(options.workers), initializer=init_worker)
-    
-    taken_screenshots = [r for r in pool.imap(func=craft_cmd, iterable=izip(url_list, itertools.repeat(options)))]
-    
+
+    # One browser to control them all \o/...
+    if (options.renderer == 'chrome') or (options.renderer == 'chromium'):
+        # Execute ChromX in remote debigging mode (Devtools server):
+        chromx_debugger_exec(options)
+        logger_gen.debug("Waiting for Devtools server to load...")
+        while True:
+            time.sleep(1)
+            response = getWebSocketData()
+            if response["code"] == "OK":
+                browserControler = response["WS"]
+                logger_gen.debug("Devtools server ready.\n")
+                break
+
+    taken_screenshots = [
+        r for r in pool.imap(
+            func=craft_cmd,
+            iterable=izip(
+                url_list,
+                itertools.repeat(options)
+            )
+        )
+    ]
+
+    # Closes Devtools server:
+    if (options.renderer == 'chrome') or (options.renderer == 'chromium'):
+        asyncio.get_event_loop().run_until_complete(
+            chromx_terminate(browserControler)
+        )
+
     pool.close()
     pool.join()
+
     
     screenshots_error_url = [url for retval, url in taken_screenshots if retval == SHELL_EXECUTION_ERROR]
     screenshots_error = sum(retval == SHELL_EXECUTION_ERROR for retval, url in taken_screenshots)
@@ -577,7 +1129,6 @@ def main():
             parser.error('Please specify a valid crop rectangle')
     
     url_list = parse_targets(options)
-    
     take_screenshot(url_list, options)
     
     return None


### PR DESCRIPTION
Added Devtools protocol support for Chromium based browsers.
Options now available for those browsers:
* -f or --format (PDF, JPG, JPEG and PNG)
* -q or --quality (Only for JPG or JPEG files)
* --crop
* -c or --cookie
* -a or --header ("Host header not allowed due to a Chromium engine bug still not fixed.")

Additionaly, one more option was created:
* -d or --delay: In seconds, delay before the screenshots are taken (only for these type of renderer).

I will add a work around for the HTTP Host header in my personal repository, I don't include this work around here because it's very messy, and to be honest, I don't think that many people would benefit from it. I need these because some times I want to screenshot against some WAF protected sites directly using the IP address, but for virtual hosts I need to inject the host header.

It's was very easy to add new functionality to the code because it's very well structured.
Thanks for this amazing tool.